### PR TITLE
javaxからjakartaへservlet-apiを変更

### DIFF
--- a/bizprint-server-java/pom.xml
+++ b/bizprint-server-java/pom.xml
@@ -40,12 +40,18 @@
             <version>2.11.3</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.3</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
         <!-- 置換後のtemp-srcをソースディレクトリに設定 -->

--- a/bizprint-server-java/src/main/java/com/brainsellers/bizstream/bizprint/PDFDirectPrintStream.java
+++ b/bizprint-server-java/src/main/java/com/brainsellers/bizstream/bizprint/PDFDirectPrintStream.java
@@ -21,7 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.Logger;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *  ダイレクト印刷のストリームを生成するためのクラスです。


### PR DESCRIPTION
## 概要

- javaxからjakartaへservlet-apiを変更
- JDK互換バージョンを1.8に設定

## 関連イシュー

Closes #19

## チェックリスト

- [x] 動作確認済み
- [x] CI通過
- [ ] 関係者にレビュー依頼済み
