### PR TITLE
build/pom.xml をプロジェクトルートへ移動

### DIFF
--- a/.claude/skills/maven-build/SKILL.md
+++ b/.claude/skills/maven-build/SKILL.md
@@ -12,13 +12,13 @@ Maven 一括ビルドを実行する。
 ### クリーンビルド（フルビルド）
 
 ```bash
-mvn -f build/pom.xml clean install
+mvn clean install
 ```
 
 ### パッケージビルド
 
 ```bash
-mvn -f build/pom.xml clean package
+mvn clean package
 ```
 
 ## 注意事項

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: java -version
 
       - name: Build with Maven
-        run: mvn -f build/pom.xml clean install -B
+        run: mvn clean install -B
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ bizprint は biz-Stream の印刷系モジュールを独立させたもの。
 | `bizprint-server-java` | Java | spp ファイル生成ライブラリ（サーバー側） |
 | `bizprint-server-csharp` | C# | spp ファイル生成ライブラリ（サーバー側） |
 | `bizprint-client` | C# | ダイレクト印刷・バッチ印刷 Windows クライアント |
-| `build` | Maven | 一括ビルド用親プロジェクト |
+| `pom.xml`（ルート） | Maven | 一括ビルド用親プロジェクト |
 
 ### bizprint-client の内部構成
 | プロジェクト | 責務 |
@@ -59,7 +59,6 @@ bizprint は biz-Stream の印刷系モジュールを独立させたもの。
 
 ### ビルド方法
 ```bash
-cd build
 mvn clean install
 ```
 
@@ -105,5 +104,5 @@ mvn clean install
 - CI が通っていない PR はマージしない。
 
 ## CI
-- GitHub Actions（self-hosted Windows ランナー）で `mvn -f build/pom.xml clean install` を実行。
+- GitHub Actions（self-hosted Windows ランナー）で `mvn clean install` を実行。
 - PR 作成時と main への push 時に自動実行。

--- a/bizprint-client/pom.xml
+++ b/bizprint-client/pom.xml
@@ -21,7 +21,7 @@
         <groupId>com.brainsellers.bizstream.bizprint</groupId>
         <artifactId>bizprint-parent</artifactId>
         <version>1.0.0</version>
-        <relativePath>../build/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>com.brainsellers.bizstream.bizprint</groupId>

--- a/bizprint-server-csharp/pom.xml
+++ b/bizprint-server-csharp/pom.xml
@@ -21,7 +21,7 @@
         <groupId>com.brainsellers.bizstream.bizprint</groupId>
         <artifactId>bizprint-parent</artifactId>
         <version>1.0.0</version>
-        <relativePath>../build/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>com.brainsellers.bizstream.bizprint</groupId>

--- a/bizprint-server-java/pom.xml
+++ b/bizprint-server-java/pom.xml
@@ -25,7 +25,7 @@
         <groupId>com.brainsellers.bizstream.bizprint</groupId>
         <artifactId>bizprint-parent</artifactId>
         <version>1.0.0</version>
-        <relativePath>../build/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>com.brainsellers.bizstream.bizprint</groupId>
@@ -51,6 +51,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <checkstyle.skip>false</checkstyle.skip>
+        <editorconfig.skip>false</editorconfig.skip>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,17 @@
     <name>bizprint Parent Project</name>
 
     <modules>
-        <module>../bizprint-server-java</module>
-        <module>../bizprint-server-csharp</module>
-        <module>../bizprint-client</module>
+        <module>bizprint-server-java</module>
+        <module>bizprint-server-csharp</module>
+        <module>bizprint-client</module>
         <!-- 他のサブプロジェクトを順番に追加 -->
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- 親プロジェクトにはJavaソースがないためスキップ。子モジュールで個別に設定する -->
+        <checkstyle.skip>true</checkstyle.skip>
+        <editorconfig.skip>true</editorconfig.skip>
     </properties>
 
     <!-- 暗号化キーを固定したい場合はここでセットする -->


### PR DESCRIPTION
## Summary

- `build/pom.xml` をプロジェクトルートへ `git mv` で移動し、標準的な Maven マルチモジュール構成にした
- IntelliJ でプロジェクトを開いた際にサブモジュールを正しく認識できるようになる
- 各サブモジュールの `relativePath`、CI ワークフロー、ドキュメントのビルド手順を更新

## 変更内容

- `build/pom.xml` → `pom.xml`: modules パスを `bizprint-*` に変更
- 親 POM: `checkstyle.skip=true`, `editorconfig.skip=true` を追加（Java ソースがないため）
- `bizprint-server-java/pom.xml`: `checkstyle.skip=false`, `editorconfig.skip=false` を明示
- 3 サブモジュール: `relativePath` を `../pom.xml` に変更
- `.github/workflows/build.yml`: `mvn -f build/pom.xml clean install -B` → `mvn clean install -B`
- `CLAUDE.md`, `README.md`, `SKILL.md`: ビルド手順を更新

## Test plan

- [x] プロジェクトルートから `mvn clean install` を実行し、4 モジュールすべて BUILD SUCCESS を確認
- [ ] CI（GitHub Actions）でビルドが通ることを確認

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)