### PR TITLE
Ant replaceタスクにencoding属性を追加してIntelliJビルドのエンコーディング問題を修正

### DIFF
--- a/bizprint-client/pom.xml
+++ b/bizprint-client/pom.xml
@@ -104,13 +104,17 @@
 
                                 <!-- 置換処理：テンポラリディレクトリ内のファイルを置換 -->
                                 <replace file="${project.build.directory}/temp-src/BizPrintCommon/CommonConstants.cs"
-                                         token="___RANDOM_STRINGS1___" value="${randomString1}"/>
+                                         token="___RANDOM_STRINGS1___" value="${randomString1}"
+                                         encoding="ISO-8859-1"/>
                                 <replace file="${project.build.directory}/temp-src/BizPrintCommon/CommonConstants.cs"
-                                         token="___RANDOM_STRINGS2___" value="${randomString2}"/>
+                                         token="___RANDOM_STRINGS2___" value="${randomString2}"
+                                         encoding="ISO-8859-1"/>
                                 <replace file="${project.build.directory}/temp-src/SppFileExtractTool/SppExtracorForTool.cs"
-                                         token="___RANDOM_STRINGS1___" value="${randomString1}"/>
+                                         token="___RANDOM_STRINGS1___" value="${randomString1}"
+                                         encoding="ISO-8859-1"/>
                                 <replace file="${project.build.directory}/temp-src/SppFileExtractTool/SppExtracorForTool.cs"
-                                         token="___RANDOM_STRINGS2___" value="${randomString2}"/>
+                                         token="___RANDOM_STRINGS2___" value="${randomString2}"
+                                         encoding="ISO-8859-1"/>
 
                                 <!-- プロパティのデバッグ出力 -->
                                 <echo>

--- a/bizprint-server-java/pom.xml
+++ b/bizprint-server-java/pom.xml
@@ -128,11 +128,13 @@
                                 <replace
                                     file="${project.build.directory}/temp-src/com/brainsellers/bizstream/bizprint/CreateEncryptSpp.java"
                                     token="___RANDOM_STRINGS1___"
-                                    value="${randomString1}" />
+                                    value="${randomString1}"
+                                    encoding="UTF-8" />
                                 <replace
                                     file="${project.build.directory}/temp-src/com/brainsellers/bizstream/bizprint/CreateEncryptSpp.java"
                                     token="___RANDOM_STRINGS2___"
-                                    value="${randomString2}" />
+                                    value="${randomString2}"
+                                    encoding="UTF-8" />
 
                                 <!-- プロパティのデバッグ出力 -->
                                 <echo>


### PR DESCRIPTION
## Summary
- `bizprint-server-java/pom.xml`: Antの`<replace>`タスクに`encoding="UTF-8"`を追加（日本語コメントの破損を防止）
- `bizprint-client/pom.xml`: Antの`<replace>`タスクに`encoding="ISO-8859-1"`を追加（UTF-8 BOMを含む全バイトを保存）
- JVMのデフォルトエンコーディングに依存しなくなり、ターミナル/IntelliJどちらでも同じビルド結果になる

## Test plan
- [x] ターミナルから`mvn clean install`でビルド成功を確認
- [x] ランダム文字列の置換がJava/C#両方で正しく行われていることを確認
- [x] C#ファイルのUTF-8 BOM（`EF BB BF`）が保存されていることを確認
- [x] IntelliJ IDEAからのビルド成功を確認（`-Dfile.encoding=UTF-8`なしで）
- [ ] CIでのビルド成功を確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)