### PR TITLE
CodeQL指摘対応: build.yml の permissions 追加と XXE 脆弱性修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch: # 手動実行も可能
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build on Windows Runner

--- a/bizprint-server-java/src/main/java/com/brainsellers/bizstream/bizprint/PDFJaxpStatusParser.java
+++ b/bizprint-server-java/src/main/java/com/brainsellers/bizstream/bizprint/PDFJaxpStatusParser.java
@@ -54,6 +54,9 @@ public class PDFJaxpStatusParser extends PDFCommonStatusParser {
      */
     public void parse(InputStream input) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(input);
 


### PR DESCRIPTION
## Summary

- `build.yml` にワークフローレベルの `permissions: contents: read` を追加（[alert #1](https://github.com/biz-Stream/bizprint/security/code-scanning/1)）
- `PDFJaxpStatusParser` の `DocumentBuilderFactory` に DTD/外部エンティティ無効化設定を追加し、XXE 脆弱性を修正（[alert #2](https://github.com/biz-Stream/bizprint/security/code-scanning/2)）

## Test plan

- [x] `mvn clean install` ビルド成功を確認済み
- [ ] CI ビルド成功を確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)