### PR TITLE
リリースワークフローの prerelease 判定を PowerShell に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Determine if prerelease
         id: prerelease
         shell: pwsh
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          $tag = "${{ github.ref_name }}"
-          if ($tag -match '-(alpha|beta|rc)') {
+          if ($env:TAG -match '-(alpha|beta|rc)') {
             "is_prerelease=true" | Out-File -Append -FilePath $env:GITHUB_OUTPUT
           } else {
             "is_prerelease=false" | Out-File -Append -FilePath $env:GITHUB_OUTPUT


### PR DESCRIPTION
## 概要

- self-hosted Windows ランナーに bash がないため、release.yml の「Determine if prerelease」ステップが `bash: command not found` で失敗していた
- `shell: bash` を `shell: pwsh` に変更し、スクリプトを PowerShell 構文に書き換え

## 関連イシュー

Closes #59

## チェックリスト

- [ ] 動作確認済み
- [ ] CI通過
- [ ] 関係者にレビュー依頼済み