### PR TITLE
chore: GitHub Organization リネームに伴いリポジトリ内 URL を更新する

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: セキュリティに関する報告
-    url: https://github.com/biz-Stream/bizprint/security
+    url: https://github.com/brainsellers-com/bizprint/security
     about: 脆弱性の報告は Issue ではなく、セキュリティページから非公開で報告してください。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,9 @@
 - 暗号化キー自動生成に対応
 - Inno Setup インストーラーを追加
 
-[Unreleased]: https://github.com/biz-Stream/bizprint/compare/v1.0.0-rc2...HEAD
-[1.0.0-rc2]: https://github.com/biz-Stream/bizprint/compare/v1.0.0-rc1...v1.0.0-rc2
-[1.0.0-rc1]: https://github.com/biz-Stream/bizprint/compare/v1.0.0-alpha3...v1.0.0-rc1
-[1.0.0-alpha3]: https://github.com/biz-Stream/bizprint/compare/v1.0.0-alpha2...v1.0.0-alpha3
-[1.0.0-alpha2]: https://github.com/biz-Stream/bizprint/compare/v1.0.0-alpha1...v1.0.0-alpha2
-[1.0.0-alpha1]: https://github.com/biz-Stream/bizprint/releases/tag/v1.0.0-alpha1
+[Unreleased]: https://github.com/brainsellers-com/bizprint/compare/v1.0.0-rc2...HEAD
+[1.0.0-rc2]: https://github.com/brainsellers-com/bizprint/compare/v1.0.0-rc1...v1.0.0-rc2
+[1.0.0-rc1]: https://github.com/brainsellers-com/bizprint/compare/v1.0.0-alpha3...v1.0.0-rc1
+[1.0.0-alpha3]: https://github.com/brainsellers-com/bizprint/compare/v1.0.0-alpha2...v1.0.0-alpha3
+[1.0.0-alpha2]: https://github.com/brainsellers-com/bizprint/compare/v1.0.0-alpha1...v1.0.0-alpha2
+[1.0.0-alpha1]: https://github.com/brainsellers-com/bizprint/releases/tag/v1.0.0-alpha1

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ Issue、およびこの行動規範に沿っていないその他のコントリ
 ## 執行
 
 暴力的、ハラスメント的、またはその他の受け入れられない行動の事例は、
-GitHub の [Private vulnerability reporting](https://github.com/biz-Stream/bizprint/security)
+GitHub の [Private vulnerability reporting](https://github.com/brainsellers-com/bizprint/security)
 機能を通じて、執行責任を持つコミュニティリーダーに非公開で報告してください。
 
 すべての苦情は迅速かつ公正にレビューおよび調査されます。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 GitHub の **Private vulnerability reporting** 機能を使用してください。
 
-1. [bizprint のセキュリティページ](https://github.com/biz-Stream/bizprint/security) にアクセス
+1. [bizprint のセキュリティページ](https://github.com/brainsellers-com/bizprint/security) にアクセス
 2. 「Report a vulnerability」をクリック
 3. 脆弱性の詳細を記入して送信
 

--- a/bizprint-client/src/BatchPrintInstaller/BatchPrint-OSS.iss
+++ b/bizprint-client/src/BatchPrintInstaller/BatchPrint-OSS.iss
@@ -24,7 +24,7 @@
 ; 会社やサイトなど
 #define MyAppPublisher "ブレインセラーズ・ドットコム株式会社"
 ; プログラムを提供するURLなど
-#define MyAppURL "https://github.com/biz-Stream/bizprint"
+#define MyAppURL "https://github.com/brainsellers-com/bizprint"
 ; プログラムの実行ファイル名
 #define MyAppExeName "BatchPrintService.exe"
 ; インストーラのファイル名 (バージョン番号と.exeより前の部分)
@@ -184,7 +184,7 @@ Name: "{commonappdata}\brainsellers\BatchPrint\tmp"; Permissions: everyone-full
 [Icons]
 ;Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{group}\GitHub"; Filename: "https://github.com/biz-Stream/bizprint"; WorkingDir: "{autoprograms}"
+Name: "{group}\GitHub"; Filename: "https://github.com/brainsellers-com/bizprint"; WorkingDir: "{autoprograms}"
 Name: "{group}\設定フォルダ"; Filename: "{commonappdata}\brainsellers\BatchPrint"; WorkingDir: "{autoprograms}"
 Name: "{group}\{#MyAppName}のアンインストール"; Filename: "{uninstallexe}"; IconFilename: "{uninstallexe}"
 ;Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/bizprint-client/src/DirectPrintInstaller/DirectPrint-OSS.iss
+++ b/bizprint-client/src/DirectPrintInstaller/DirectPrint-OSS.iss
@@ -24,7 +24,7 @@
 ; 会社やサイトなど
 #define MyAppPublisher "ブレインセラーズ・ドットコム株式会社"
 ; プログラムを提供するURLなど
-#define MyAppURL "https://github.com/biz-Stream/bizprint"
+#define MyAppURL "https://github.com/brainsellers-com/bizprint"
 ; プログラムの実行ファイル名
 #define MyAppExeName "DirectPrintService.exe"
 ; インストーラのファイル名 (バージョン番号と.exeより前の部分)
@@ -191,7 +191,7 @@ Name: "{commonappdata}\brainsellers\DirectPrint\tmp"; Permissions: everyone-full
 ; スタートメニューやデスクトップにショートカットアイコンを登録する設定
 ;-------------------------------------------------------------------------
 [Icons]
-Name: "{group}\GitHub"; Filename: "https://github.com/biz-Stream/bizprint"; WorkingDir: "{autoprograms}"
+Name: "{group}\GitHub"; Filename: "https://github.com/brainsellers-com/bizprint"; WorkingDir: "{autoprograms}"
 Name: "{group}\設定フォルダ"; Filename: "{commonappdata}\brainsellers\DirectPrint"; WorkingDir: "{autoprograms}"
 Name: "{group}\{#MyAppName}のアンインストール"; Filename: "{uninstallexe}"; IconFilename: "{uninstallexe}"
 


### PR DESCRIPTION
## Summary
- GitHub Organization を `biz-Stream` から `brainsellers-com` にリネームしたため、リポジトリ内の GitHub URL を一括更新
- 対象: CHANGELOG.md, CODE_OF_CONDUCT.md, SECURITY.md, ISSUE_TEMPLATE/config.yml, DirectPrint-OSS.iss, BatchPrint-OSS.iss

Closes #67

## Test plan
- [ ] 各ファイルの URL が `brainsellers-com/bizprint` に更新されていること
- [ ] CI ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)