### PR TITLE
open-memory.cmd を追加する

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ indent_size = 4
 [*.iss]
 indent_style = space
 indent_size = 2
+
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/open-memory.cmd
+++ b/open-memory.cmd
@@ -1,0 +1,5 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$h = (Get-Location).Path -replace '[^a-zA-Z0-9\-]', '-';" ^
+  "$m = \"$env:USERPROFILE\.claude\projects\$h\memory\";" ^
+  "if (Test-Path $m) { explorer $m } else { Write-Host ('memory フォルダが見つかりません: ' + $m); pause }"


### PR DESCRIPTION
## 概要

Claude Code の memory フォルダを Explorer で開くユーティリティスクリプト `open-memory.cmd` を追加する。
biz-Stream #130 と同様の対応。`.editorconfig` に cmd/bat の CRLF 設定も追加。

## 関連イシュー

Closes #77

## チェックリスト

- [x] 動作確認済み
- [x] CI通過
- [ ] CHANGELOG.md を更新済み（該当する場合）
- [ ] 関係者にレビュー依頼済み