### PR TITLE
chore: ドキュメント内の brainsellers.com URL を tecnos.co.jp/bs に置換する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # 製品概要
-bizprint は [biz-Stream](https://www.brainsellers.com/product/bizstream/) 製品のダイレクト印刷・バッチ印刷機能を
+bizprint は [biz-Stream](https://www.tecnos.co.jp/bs/biz-stream/) 製品のダイレクト印刷・バッチ印刷機能を
 オープンソース化したプロジェクトである（Apache License v2.0）。
 
 サーバーサイドで印刷データ（spp ファイル）を生成し、クライアント（Windows サービス）が受信して印刷を実行する。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # biz-Stream ダイレクト印刷・バッチ印刷 (オープンソース版)
 
-このリポジトリでは[ブレインセラーズ・ドットコム株式会社](https://www.brainsellers.com/)が提供している[biz-Stream](https://www.brainsellers.com/product/bizstream/)製品のうち、ダイレクト印刷とバッチ印刷に関するソースを公開しています。
+このリポジトリでは[ブレインセラーズ・ドットコム株式会社](https://www.tecnos.co.jp/bs/)が提供している[biz-Stream](https://www.tecnos.co.jp/bs/biz-stream/)製品のうち、ダイレクト印刷とバッチ印刷に関するソースを公開しています。
 
 ※"biz-Stream"はブレインセラーズ・ドットコム株式会社の登録商標です。
 


### PR DESCRIPTION
## 概要

ドキュメント内の `https://www.brainsellers.com` を `https://www.tecnos.co.jp/bs/` に置換する。

- `https://www.brainsellers.com/` → `https://www.tecnos.co.jp/bs/`
- `https://www.brainsellers.com/product/bizstream/` → `https://www.tecnos.co.jp/bs/biz-stream/`

## 関連イシュー

Closes #113

## チェックリスト

- [x] 動作確認済み
- [ ] CI通過
- [ ] CHANGELOG.md を更新済み（該当する場合）
- [ ] 関係者にレビュー依頼済み