### PR TITLE
chore: GitHub Actions の依存関係を一括更新する (#136)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: [self-hosted, windows-public-runner]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check Java version
         run: java -version
@@ -41,7 +41,7 @@ jobs:
         run: mvn clean install -B
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check Java version
         run: java -version
@@ -34,7 +34,7 @@ jobs:
           }
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Semgrep
         run: semgrep scan --config auto --sarif --output semgrep-results.sarif
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: semgrep-sarif
           path: semgrep-results.sarif
@@ -44,7 +44,7 @@ jobs:
     name: Secret Detection (Gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,47 @@
-/bizprint-server-csharp/src/obj
-/bizprint-server-csharp/src/bin
-/bizprint-server-csharp/src/.vs
-/bizprint-server-java/.classpath
-/bizprint-server-java/.settings
-/bizprint-server-java/target
-/bizprint-server-java/.project
-/bizprint-server-csharp/.project
-/bizprint-server-csharp/.settings
-/bizprint-server-csharp/target
-/bizprint-client/.project
-/bizprint-client/.settings
-/bizprint-client/target
-/bizprint-client/src/.vs
-/bizprint-client/src/BatchPrintInstaller/Output
-/bizprint-client/src/BatchPrintService/obj
-/bizprint-client/src/BatchPrintService/bin
-/bizprint-client/src/BizCommonTests/obj
-/bizprint-client/src/BizCommonTests/bin
-/bizprint-client/src/BizPrintCommon/obj
-/bizprint-client/src/BizPrintCommon/bin
-/bizprint-client/src/BizPrintHealthChecker/obj
-/bizprint-client/src/BizPrintHealthChecker/bin
-/bizprint-client/src/DirectPrintInstaller/Output
-/bizprint-client/src/DirectPrintService/obj
-/bizprint-client/src/DirectPrintService/bin
-/bizprint-client/src/SilentPdfPrinter/obj
-/bizprint-client/src/SilentPdfPrinter/bin
-/bizprint-client/src/SppFileExtractTool/obj
-/bizprint-client/src/SppFileExtractTool/bin
-/build/target
-/build/.settings
-/build/.project
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea/*
+!.idea/checkstyle-idea.xml
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Visual Studio ###
+**/bin/
+**/obj/
+**/.vs/
+*.suo
+
+### Inno Setup ###
+**/Output/
+
+### Claude Code ###
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>13.1.0</checkstyleVersion>
+    <scanScope>JavaOnly</scanScope>
+    <copyLibs>true</copyLibs>
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
## 概要

GitHub Actions の依存関係を一括更新し、`.gitignore` を整備する。

- actions/checkout v4 → v6
- actions/upload-artifact v4 → v7
- softprops/action-gh-release v2 → v3
- `.gitignore` をモジュール個別指定からグローバルパターンに統一

## 変更サマリー

### 何を変えたか
GitHub Actions の依存関係を一括更新:
- `actions/upload-artifact` 4 → 7
- `actions/checkout` 4 → 6
- `softprops/action-gh-release` 2.5.0 → 3.0.0

追加: `.gitignore` をモジュール個別指定からグローバルパターンに統一。

### なぜ変えたか
Dependabot による定期的な依存関係更新。個別 PR を1つにまとめて効率化。
`.gitignore` は他プロジェクト（biz-stream, bizservice）と構成を揃えるため整備。

### 影響範囲
CI ワークフロー（build.yml, release.yml, security.yml）のみ。アプリケーションコードへの影響なし。

### 注意点
GitHub Actions のメジャーバージョンアップのため、破壊的変更がないか CI 実行結果で確認が必要。

## 関連イシュー

Closes #136

Supersedes #131, #132, #133

## チェックリスト

- [x] 動作確認済み
- [ ] CI通過
- [ ] 関係者にレビュー依頼済み