### PR TITLE
chore: イシューラベリングルール導入（type:/comp: 必須付与体系） (#146)

### DIFF
--- a/.claude/rules/issue-labels.md
+++ b/.claude/rules/issue-labels.md
@@ -1,0 +1,65 @@
+# イシューラベル付与ルール
+
+イシュー作成時（手動・CLI 問わず）および既存イシューへの着手時に適用するラベリング規約。
+
+## ラベル体系
+
+| 軸 | ラベル | 付与タイミング |
+|---|---|---|
+| 種別 | `type: bug` / `type: task` / `type: enhancement` / `type: feature` | **必須・1 つ**。作成時に付与 |
+| コンポーネント | `comp: *`（下表参照） | **必須・1 つ**。作成時に付与 |
+| 優先度 | `priority: blocker` / `priority: critical` / `priority: major` / `priority: minor` / `priority: trivial` | **任意**。明確な場合のみ |
+| 解決区分 | `wontfix` / `duplicate` / `worksforme` / `invalid` | クローズ時のみ |
+
+### 種別（type）の判定基準
+
+| type ラベル | 用途 | ブランチプレフィックス対応 |
+|---|---|---|
+| `type: bug` | バグ・不具合の修正 | `bugfix/` `hotfix/` |
+| `type: task` | 設定変更・リファクタリング・ドキュメント・テスト・雑務 | `chore/` `docs/` `refactor/` `test/` |
+| `type: enhancement` | **既存**機能の改善・拡張 | `feature/`（既存改善の場合） |
+| `type: feature` | **新規**機能の追加 | `feature/`（新規の場合） |
+
+`feature/` プレフィックスでは新規追加か既存改善かを判断して `type: feature` または `type: enhancement` を選択する。迷う場合は `type: feature` をデフォルトとする。
+
+### コンポーネント（comp）一覧
+
+| ラベル | 対象 |
+|---|---|
+| `comp: server-java` | bizprint-server-java（Java 版 spp 生成ライブラリ） |
+| `comp: server-csharp` | bizprint-server-csharp（C# 版 spp 生成ライブラリ） |
+| `comp: client` | bizprint-client（Windows 印刷クライアント） |
+| `comp: ci` | GitHub Actions・CI・リリースワークフロー |
+| `comp: docs` | ドキュメント（docs/ 配下） |
+| `comp: claude` | Claude Code スキル・ルール・プラグイン運用 |
+| `comp: sample` | サンプルコード（sample/ 配下） |
+| `comp: general` | 横断・その他 |
+
+横断的なタスク（リポジトリ設定・依存更新等）でコンポーネントが特定できない場合は `comp: general` を使用する。
+
+### 優先度（priority）の運用方針
+
+- **不明な場合は付けない**。確信がある場合のみ付与する
+- 判断の目安: `blocker`（リリースブロッカー）、`critical`（クラッシュ・データ破損）、`major`（主要機能の不具合）、`minor`（軽微な問題）、`trivial`（表示上の些細な問題）
+
+## 既存イシューのラベル補完
+
+start-task で既存イシューに着手する際、`type: *` または `comp: *` が欠けている場合はイシューの内容から判定して補完する。
+
+- `gh issue view <番号> --json labels,title,body` で現在のラベルを確認する
+- `type: *` ラベルが 1 つもなければ、内容から判定して `gh issue edit <番号> --add-label "type: <種別>"` で追加する
+- `comp: *` ラベルが 1 つもなければ、内容から判定して `gh issue edit <番号> --add-label "comp: <コンポーネント>"` で追加する
+- **既に付いているラベルは変更・削除しない**（`--add-label` のみ使用）
+- 判定結果はユーザーに提示してから適用する
+
+想定ケース: QA チームが別リポジトリの CLI からイシューを起票した場合など、issue form を通らずラベルなしで作成されるイシュー。
+
+## gh コマンド例
+
+```powershell
+# ラベル付きでイシュー作成
+gh issue create --title "<タイトル>" --body $body --assignee "@me" --label "type: task" --label "comp: general"
+
+# 既存イシューにラベルを追加
+gh issue edit <番号> --add-label "type: bug" --add-label "comp: server-java"
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: バグ報告
 description: バグや不具合を報告する
-labels: ["bug"]
+labels: ["type: bug"]
 body:
   - type: markdown
     attributes:
@@ -46,15 +46,20 @@ body:
       required: true
 
   - type: dropdown
-    id: module
+    id: component
     attributes:
-      label: 対象モジュール
-      description: 該当するモジュールを選択してください。
+      label: コンポーネント
+      description: 該当するコンポーネントを選択してください。
       options:
-        - bizprint-server-java
-        - bizprint-server-csharp
-        - bizprint-client
-        - その他
+        - server-java（bizprint-server-java）
+        - server-csharp（bizprint-server-csharp）
+        - client（bizprint-client）
+        - ci（GitHub Actions・CI）
+        - docs（ドキュメント）
+        - claude（Claude Code スキル・ルール）
+        - sample（サンプルコード）
+        - general（横断・その他）
+        - 不明
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: 機能要望
 description: 新機能や改善の提案をする
-labels: ["enhancement"]
+labels: ["type: enhancement"]
 body:
   - type: markdown
     attributes:
@@ -34,15 +34,20 @@ body:
       required: false
 
   - type: dropdown
-    id: module
+    id: component
     attributes:
-      label: 対象モジュール
-      description: 該当するモジュールを選択してください。
+      label: コンポーネント
+      description: 該当するコンポーネントを選択してください。
       options:
-        - bizprint-server-java
-        - bizprint-server-csharp
-        - bizprint-client
-        - その他
+        - server-java（bizprint-server-java）
+        - server-csharp（bizprint-server-csharp）
+        - client（bizprint-client）
+        - ci（GitHub Actions・CI）
+        - docs（ドキュメント）
+        - claude（Claude Code スキル・ルール）
+        - sample（サンプルコード）
+        - general（横断・その他）
+        - 不明
     validations:
       required: true
 

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,59 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-component-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // nosemgrep: javascript.github-actions.security.audit.github-actions-untrusted-input
+            // context.payload.issue.body は github-script 内の JavaScript 変数アクセスであり、
+            // Actions のテンプレート式展開とは異なりスクリプトインジェクションのリスクはない。
+            // さらにホワイトリスト照合で出力値を制限している。
+            const body = context.payload.issue.body || '';
+
+            // issue form のコンポーネントドロップダウンの値を抽出する。
+            // issue form は "### コンポーネント\n\n<選択値>" の形式で本文に展開される。
+            const match = body.match(/### コンポーネント\s*\n\n(.+)/);
+            if (!match) {
+              console.log('コンポーネントフィールドが見つかりません（CLI 作成等）。スキップします。');
+              return;
+            }
+
+            const selected = match[1].trim();
+
+            if (selected === '不明' || selected === '_No response_' || selected === '') {
+              console.log(`コンポーネント選択が "${selected}" のためラベルを付与しません。`);
+              return;
+            }
+
+            // ドロップダウンの選択肢からラベル名を抽出する。
+            // 選択肢の形式: "server-java（bizprint-server-java）" → ラベル: "comp: server-java"
+            const compName = selected.split('（')[0].trim();
+
+            // ホワイトリスト照合（スクリプトインジェクション防止）
+            const validComps = [
+              'server-java', 'server-csharp', 'client', 'ci',
+              'docs', 'claude', 'sample', 'general'
+            ];
+            if (!validComps.includes(compName)) {
+              console.log(`コンポーネント名 "${compName}" がホワイトリストに一致しません。スキップします。`);
+              return;
+            }
+
+            const label = `comp: ${compName}`;
+            console.log(`コンポーネントラベルを付与: ${label}`);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label]
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,20 @@ mvn editorconfig:check -pl bizprint-server-java
 - CI が通っていない PR はマージしない。
 - **PR 承認は責任者のみ**。詳細: `.claude/rules/pr-approval.md`
 
+## イシューラベル付与ルール
+
+詳細は `.claude/rules/issue-labels.md` を参照。
+
+### 新規イシュー作成時
+
+| ブランチプレフィックス | type ラベル |
+|---|---|
+| `feature/` | `type: feature`（新規）または `type: enhancement`（既存改善） |
+| `bugfix/` `hotfix/` | `type: bug` |
+| `chore/` `docs/` `refactor/` `test/` | `type: task` |
+
+`comp: *` はイシュー内容から判定する。横断タスクは `comp: general`。
+
 ## コミットメッセージ規約
 - フォーマット: `<プレフィックス> <変更内容の要約（日本語）> (#<イシュー番号>)`
 - プレフィックス: `feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:`


### PR DESCRIPTION
## 概要

biz-stream で先行導入済みのイシューラベリング体系（type:/comp: 必須付与）を bizprint に導入する。

Closes #146

## 変更内容

1. `.claude/rules/issue-labels.md` 新規作成 — ラベリング規約の正本（type 4種・comp 8種・priority・解決区分）
2. `CLAUDE.md` に「イシューラベル付与ルール」セクション追加 — start-task 連携
3. `.github/ISSUE_TEMPLATE/bug_report.yml` — 「対象モジュール」を「コンポーネント」ドロップダウンに置換、ラベルを `type: bug` に変更
4. `.github/ISSUE_TEMPLATE/feature_request.yml` — 同上（ラベルは `type: enhancement`）
5. `.github/workflows/issue-labeler.yml` 新規作成 — イシュー作成時に comp: ラベルを自動付与（semgrep nosemgrep 対策・ホワイトリスト照合済み）
6. 既存イシュー 30件に type:/comp: ラベルを一括付与済み

## comp 分類

| ラベル | 対象 |
|---|---|
| `comp: server-java` | bizprint-server-java |
| `comp: server-csharp` | bizprint-server-csharp |
| `comp: client` | bizprint-client |
| `comp: ci` | GitHub Actions・CI |
| `comp: docs` | ドキュメント |
| `comp: claude` | Claude Code スキル・ルール |
| `comp: sample` | サンプルコード |
| `comp: general` | 横断・その他 |

## semgrep 対策

`issue-labeler.yml` で `context.payload.issue.body` を参照する箇所に bizservice と同じ対策を実施:
- `nosemgrep: javascript.github-actions.security.audit.github-actions-untrusted-input` コメント
- ホワイトリスト照合で出力値を制限
- 抑制理由をコメントで明記